### PR TITLE
add simple load balancer

### DIFF
--- a/src/nameserver/nameserver_impl.cc
+++ b/src/nameserver/nameserver_impl.cc
@@ -92,15 +92,12 @@ public:
 
         //insert sort according chunkserver load
         while(it != _heartbeat_list.rend()) {
-            if (chunkserver_load.empty()) {
-                chunkserver_load.push_back(std::make_pair(it->first, it->second->data_size()));
-            } else {
-                for (load_it = chunkserver_load.begin(); load_it != chunkserver_load.end(); load_it++) {
-                    if (it->second->data_size() < load_it->second)
-                        break;
-                }
-                chunkserver_load.insert(load_it, std::make_pair(it->first, it->second->data_size()));
+            for (load_it = chunkserver_load.begin(); load_it != chunkserver_load.end(); load_it++) {
+                if (it->second->data_size() < load_it->second)
+                    break;
             }
+            chunkserver_load.insert(load_it, std::make_pair(it->first, it->second->data_size()));
+
             it++;
         }
 

--- a/src/nameserver/nameserver_impl.cc
+++ b/src/nameserver/nameserver_impl.cc
@@ -113,6 +113,20 @@ public:
             return it->second->address();
         }
     }
+    bool SetChunkServerLoad(int32_t id, int64_t size) {
+        MutexLock lock(&_mu);
+        ServerMap::iterator it = _chunkservers.find(id);
+        if(it == _chunkservers.end()) {
+            LOG(WARNING, "ChunkServer does not exist!, chunkserver id: %ld\n", id); 
+            assert(0);
+            return false;
+        } else {
+            it->second->set_data_size(size);
+            LOG(INFO, "Get Report of ChunkServerLoad, server id: %ld, load: %ld\n", id, size);
+            return true;
+        }
+    }
+
 private: 
     Mutex _mu;      /// _chunkservers list mutext;
     typedef std::map<int32_t, ChunkServerInfo*> ServerMap;
@@ -220,10 +234,13 @@ void NameServerImpl::BlockReport(::google::protobuf::RpcController* controller,
         response->set_status(8882);
     } else {
         const ::google::protobuf::RepeatedPtrField<ReportBlockInfo>& blocks = request->blocks();
+        int64_t size = 0;
         for (int i = 0; i < blocks.size(); i++) {
             const ReportBlockInfo& block =  blocks.Get(i);
             _block_manager->AddBlock(block.block_id(), id, block.block_size());
+            size += block.block_size();
         }
+        _chunkserver_manager->SetChunkServerLoad(id, size);
     }
     done->Run();
 }


### PR DESCRIPTION
add a very very simple load balancer

when handle BlockReport rpc, nameserver
record the total size of blocks in every chunkserver

when handle GetChunkserverChains, select
chunkservers with lowest total size first.

so it's a very versy simple load balancer..
replace it by more complex strategy later? like GFS?