### PR TITLE
add simple load balancer

### DIFF
--- a/src/chunkserver/chunkserver_impl.cc
+++ b/src/chunkserver/chunkserver_impl.cc
@@ -383,7 +383,7 @@ void ChunkServerImpl::Routine() {
     int64_t next_report = -1;
     while (!_quit) {
         // heartbeat
-        if (ticks%FLAGS_heartbeat_interval == 0) {
+        if (ticks % FLAGS_heartbeat_interval == 0) {
             HeartBeatRequest request;
             request.set_chunkserver_id(_chunkserver_id);
             request.set_data_server_addr(_data_server_addr);

--- a/src/nameserver/nameserver_impl.cc
+++ b/src/nameserver/nameserver_impl.cc
@@ -92,15 +92,12 @@ public:
 
         //insert sort according chunkserver load
         while(it != _heartbeat_list.rend()) {
-            if (chunkserver_load.empty()) {
-                chunkserver_load.push_back(std::make_pair(it->first, it->second->data_size()));
-            } else {
-                for (load_it = chunkserver_load.begin(); load_it != chunkserver_load.end(); load_it++) {
-                    if (it->second->data_size() < load_it->second)
-                        break;
-                }
-                chunkserver_load.insert(load_it, std::make_pair(it->first, it->second->data_size()));
+            for (load_it = chunkserver_load.begin(); load_it != chunkserver_load.end(); load_it++) {
+                if (it->second->data_size() < load_it->second)
+                    break;
             }
+            chunkserver_load.insert(load_it, std::make_pair(it->first, it->second->data_size()));
+
             it++;
         }
 

--- a/src/nameserver/nameserver_impl.cc
+++ b/src/nameserver/nameserver_impl.cc
@@ -113,6 +113,20 @@ public:
             return it->second->address();
         }
     }
+    bool SetChunkServerLoad(int32_t id, int64_t size) {
+        MutexLock lock(&_mu);
+        ServerMap::iterator it = _chunkservers.find(id);
+        if(it == _chunkservers.end()) {
+            LOG(WARNING, "ChunkServer does not exist!, chunkserver id: %ld\n", id); 
+            assert(0);
+            return false;
+        } else {
+            it->second->set_data_size(size);
+            LOG(INFO, "Get Report of ChunkServerLoad, server id: %ld, load: %ld\n", id, size);
+            return true;
+        }
+    }
+
 private: 
     Mutex _mu;      /// _chunkservers list mutext;
     typedef std::map<int32_t, ChunkServerInfo*> ServerMap;
@@ -220,10 +234,13 @@ void NameServerImpl::BlockReport(::google::protobuf::RpcController* controller,
         response->set_status(8882);
     } else {
         const ::google::protobuf::RepeatedPtrField<ReportBlockInfo>& blocks = request->blocks();
+        int64_t size = 0;
         for (int i = 0; i < blocks.size(); i++) {
             const ReportBlockInfo& block =  blocks.Get(i);
             _block_manager->AddBlock(block.block_id(), id, block.block_size());
+            size += block.block_size();
         }
+        _chunkserver_manager->SetChunkServerLoad(id, size);
     }
     done->Run();
 }

--- a/src/nameserver/nameserver_impl.cc
+++ b/src/nameserver/nameserver_impl.cc
@@ -87,23 +87,18 @@ public:
             return false;
         }
         std::map<int32_t, ChunkServerInfo*>::const_reverse_iterator it = _heartbeat_list.rbegin();
-        std::vector<std::pair<int32_t, int64_t> > chunkserver_load;
-        std::vector<std::pair<int32_t, int64_t> >::iterator load_it;
+        std::vector<std::pair<int64_t, int32_t> > chunkserver_load;
+        std::vector<std::pair<int64_t, int32_t> >::iterator load_it;
 
-        //insert sort according chunkserver load
         while(it != _heartbeat_list.rend()) {
-            for (load_it = chunkserver_load.begin(); load_it != chunkserver_load.end(); load_it++) {
-                if (it->second->data_size() < load_it->second)
-                    break;
-            }
-            chunkserver_load.insert(load_it, std::make_pair(it->first, it->second->data_size()));
-
-            it++;
+            chunkserver_load.push_back(std::make_pair(it->second->data_size(), it->first));
+            ++it;
         }
+        std::sort(chunkserver_load.begin(), chunkserver_load.end());
 
         load_it = chunkserver_load.begin();
         for (int i = 0; i < num; ++i, ++load_it) {
-            ChunkServerInfo* cs = _heartbeat_list[load_it->first];
+            ChunkServerInfo* cs = _heartbeat_list[load_it->second];
             chains->push_back(std::make_pair(cs->id(), cs->address()));
         }
 


### PR DESCRIPTION
add a very very simple load balancer

when handle BlockReport rpc, nameserver
record the total size of blocks in every chunkserver

when handle GetChunkserverChains, select
chunkservers with lowest total size first.

so it's a very versy simple load balancer..
replace it by more complex strategy later? like GFS?