### PR TITLE
Remove obsolete blocks

### DIFF
--- a/src/chunkserver/chunkserver_impl.h
+++ b/src/chunkserver/chunkserver_impl.h
@@ -41,6 +41,7 @@ private:
                            const WriteBlockRequest* request,
                            ::google::protobuf::Closure* done,
                            ChunkServer_Stub* stub);
+    void RemoveObsoleteBlocks(std::vector<int64_t> blocks);
 private:
     BlockManager*   _block_manager;
     std::string     _data_server_addr;

--- a/src/proto/nameserver.proto
+++ b/src/proto/nameserver.proto
@@ -123,6 +123,7 @@ message BlockReportRequest {
 message BlockReportResponse {
     optional uint64 sequence_id = 1;
     optional int32 status = 2;
+    repeated int64 obsolete_blocks = 3;
 }
 
 service NameServer {


### PR DESCRIPTION
当执行Unlink时，将该文件的所有block标记为obsolete，待下次chunkserver向
nameserver做BlockReport时，若nameserver发现某个block已经被标记为obsolete，
则在response中加入这个block。chunkserver收到response后，将这些block以及其
元信息删除