### PR TITLE
Support custom replica number

### DIFF
--- a/src/chunkserver/chunkserver_impl.cc
+++ b/src/chunkserver/chunkserver_impl.cc
@@ -134,11 +134,16 @@ public:
     }
     bool Write(int32_t seq, const char* data, int32_t len) {
         LOG(INFO, "Block Write %d\n", seq);
-        char* buf = new char[len];
-        memcpy(buf, data, len);
+        char* buf = NULL;
+        if (len) {
+            buf = new char[len];
+            memcpy(buf, data, len);
+        }
         bool ret = _recv_window->Add(seq, Buffer(buf, len));
         if (!ret) {
-            delete[] buf;
+            if (buf) {
+                delete[] buf;
+            }
         }
         return ret;
     }
@@ -146,7 +151,9 @@ public:
     void WriteCallback(int32_t seq, Buffer buffer) {
         LOG(INFO, "Append done [seq:%d, %ld:%d]\n", seq, _datalen, buffer.len_);
         Append(seq, buffer.data_, buffer.len_);
-        delete[] buffer.data_;
+        if (buffer.data_) {
+            delete[] buffer.data_;
+        }
     }
     /// Append to block buffer
     void Append(int32_t seq, const char*buf, int32_t len) {
@@ -164,7 +171,9 @@ public:
             delete[] _blockbuf;
             _blockbuf = newbuf;
         }
-        memcpy(_blockbuf + _datalen, buf, len);
+        if (len) {
+            memcpy(_blockbuf + _datalen, buf, len);
+        }
         _datalen += len;
         _last_seq = seq;
     }
@@ -490,6 +499,15 @@ void ChunkServerImpl::Routine() {
                 boost::function<void ()> task =
                     boost::bind(&ChunkServerImpl::RemoveObsoleteBlocks, this, obsolete_blocks);
                 _thread_pool->AddTask(task);
+
+                std::vector<ReplicaInfo> new_replica_info;
+                for (int i = 0; i < response.new_replicas_size(); i++) {
+                    new_replica_info.push_back(response.new_replicas(i));
+                }
+                boost::function<void ()> new_replica_task =
+                    boost::bind(&ChunkServerImpl::AddNewReplica, this, new_replica_info);
+                _thread_pool->AddTask(new_replica_task);
+
             }
         }
         ++ ticks;
@@ -512,6 +530,7 @@ bool ChunkServerImpl::ReportFinish(Block* block) {
         LOG(WARNING, "Reprot finish fail: %ld\n", block->Id());
         return false;
     }
+
     LOG(INFO, "Reprot finish %ld\n", block->Id());
     return true;
 }
@@ -610,7 +629,7 @@ void ChunkServerImpl::WriteNextCallback(const WriteBlockRequest* next_request,
         block->SetWriteMode(O_WRONLY);
     }
 
-    if (!databuf.empty() && !block->Write(packet_seq, databuf.data(), databuf.size())) {
+    if (!block->Write(packet_seq, databuf.data(), databuf.size())) {
         LOG(WARNING, "Write offset[%ld] block_size[%ld] not in sliding window\n",
             offset, block->Size());
         block->DecRef();
@@ -678,6 +697,73 @@ void ChunkServerImpl::RemoveObsoleteBlocks(std::vector<int64_t> blocks) {
     for (size_t i = 0; i < blocks.size(); i++) {
         if (!_block_manager->RemoveBlock(blocks[i])) {
             LOG(WARNING, "Remove block fail: %ld\n", blocks[i]);
+        }
+    }
+}
+void ChunkServerImpl::AddNewReplica(std::vector<ReplicaInfo> new_replica_info) {
+    for (size_t i = 0; i < new_replica_info.size(); i++) {
+        int64_t block_id = new_replica_info[i].block_id();
+        Block* block = _block_manager->FindBlock(block_id, false);
+        if (block == NULL) {
+            LOG(WARNING, "ReadBlock not found: %ld\n", block_id);
+        } else {
+            char* buf = new char[256 * 1024];
+            ChunkServer_Stub* cur_chunkserver = NULL;
+            if (!_rpc_client->GetStub(new_replica_info[i].chunkserver_address(0), &cur_chunkserver)) {
+                LOG(WARNING, "Can't connect to chunkserver:%s\n",
+                        new_replica_info[i].chunkserver_address(0).c_str());
+                continue;
+            }
+            int32_t len;
+            int64_t offset = 0;
+            int64_t packet_seq = 0;
+            while((len = block->Read(buf, 256 * 1024, offset)) != -1) {
+                if (len >= 0) {
+                    WriteBlockRequest request;
+                    WriteBlockResponse response;
+                    int64_t seq = common::timer::get_micros();
+                    request.set_sequence_id(seq);
+                    request.set_block_id(block_id);
+                    request.set_databuf(buf, len);
+                    request.set_offset(offset);
+                    request.set_is_last(len == 0);
+                    request.set_packet_seq(packet_seq);
+                    request.set_is_append(false);
+                    for (int j = 1; j < new_replica_info[i].chunkserver_address_size(); j++) {
+                        request.add_chunkservers(new_replica_info[i].chunkserver_address(j));
+                    }
+                    if (!_rpc_client->SendRequest(cur_chunkserver,
+                                &ChunkServer_Stub::WriteBlock, &request, &response, 5, 3)) {
+                        LOG(WARNING, "AddNewReplica %ld rpc call fail\n", block_id);
+                        break;
+                    }
+                    if (response.status() != 0) {
+                        LOG(WARNING, "AddNewReplica %ld fail\n", block_id);
+                        break;
+                    }
+                }
+                if (len == 0) {
+                    break;
+                }
+                offset += len;
+                packet_seq++;
+            }
+            delete[] buf;
+        }
+        // send to nameserver finish
+        FinishBlockRequest request;
+        FinishBlockResponse response;
+        request.set_sequence_id(0);
+        request.set_block_id(block_id);
+        if (!_rpc_client->SendRequest(_nameserver, &NameServer_Stub::FinishBlock,
+                    &request, &response, 5, 3)) {
+            LOG(WARNING, "Fail to report finish to nameserver: %ld\n", block_id);
+        } else {
+            if (response.status() == 0) {
+                LOG(INFO, "Report add new replica finish to nameserver: %ld\n", block_id);
+            } else {
+                LOG(WARNING, "Report add new replica finish to nameserver fail: %ld\n", block_id);
+            }
         }
     }
 }

--- a/src/chunkserver/chunkserver_impl.h
+++ b/src/chunkserver/chunkserver_impl.h
@@ -8,6 +8,7 @@
 #define  BFS_TRUNKSERVER_IMPL_H_
 
 #include "proto/chunkserver.pb.h"
+#include "proto/nameserver.pb.h"
 #include "common/thread_pool.h"
 
 namespace bfs {
@@ -42,6 +43,7 @@ private:
                            ::google::protobuf::Closure* done,
                            ChunkServer_Stub* stub);
     void RemoveObsoleteBlocks(std::vector<int64_t> blocks);
+    void AddNewReplica(std::vector<ReplicaInfo> new_replica_info);
 private:
     BlockManager*   _block_manager;
     std::string     _data_server_addr;

--- a/src/client/bfs_client.cc
+++ b/src/client/bfs_client.cc
@@ -149,7 +149,7 @@ int BfsPut(bfs::FS* fs, int argc, char* argv[]) {
         }
         len += bytes;
     }
-    if (!file->Close()) {
+    if (!fs->CloseFile(file)) {
         fprintf(stderr, "close fail: %s\n", argv[3]);
         return 1;
     }

--- a/src/nameserver/nameserver_impl.cc
+++ b/src/nameserver/nameserver_impl.cc
@@ -84,6 +84,9 @@ public:
     bool GetChunkServerChains(int num, 
                               std::vector<std::pair<int32_t,std::string> >* chains) {
         MutexLock lock(&_mu);
+        if (num == 0) {
+            num = _heartbeat_list.size();
+        }
         if (num > static_cast<int>(_heartbeat_list.size())) {
             LOG(WARNING, "not enough alive chunkservers [%ld] for GetChunkServerChains [%d]\n",
                 _heartbeat_list.size(), num);
@@ -157,7 +160,9 @@ public:
         int64_t version;
         std::set<int32_t> replica;
         int64_t block_size;
-        NSBlock(int64_t block_id) : id(block_id),version(0) {}
+        int32_t expect_replica_num;
+        bool pending_change;
+        NSBlock(int64_t block_id) : id(block_id), version(0), expect_replica_num(3), pending_change(true) {}
         void AddChunkServer(int32_t chunkserver) {};
     };
     BlockManager():_next_block_id(1) {}
@@ -165,7 +170,7 @@ public:
         MutexLock lock(&_mu);
         return ++_next_block_id;
     }
-    bool AddBlock(int64_t id, int32_t server_id, int64_t block_size) {
+    bool AddBlock(int64_t id, int32_t server_id, int64_t block_size, int32_t* more_replica_num = NULL) {
         MutexLock lock(&_mu);
         NSBlock* nsblock = NULL;
         NSBlockMap::iterator it = _block_map.find(id);
@@ -186,6 +191,27 @@ public:
         }
         /// 增加一个副本, 无论之前已经有几个了, 多余的通过gc处理
         nsblock->replica.insert(server_id);
+        int32_t cur_replica_num = nsblock->replica.size();
+        int32_t expect_replica_num = nsblock->expect_replica_num;
+        if (cur_replica_num != expect_replica_num) {
+            if (!nsblock->pending_change) {
+                nsblock->pending_change = true;
+                if (cur_replica_num > expect_replica_num) {
+                    //not implement here
+                    /*
+                    int32_t reduant_num = cur_replica_num - expect_replica_num;
+                    _obsolete_blocks.insert(std::make_pair(id, reduant_num));
+                    LOG(INFO, "Remove block: %ld reduant replicas: %d\n", id, reduant_num);
+                    */
+                } else {
+                    // add new replica
+                    if (more_replica_num) {
+                        *more_replica_num = expect_replica_num - cur_replica_num;
+                        LOG(INFO, "Need to add %d new replica for block: %ld\n", *more_replica_num, id);
+                    }
+                }
+            }
+        }
         return true;
     }
     bool GetBlock(int64_t block_id, NSBlock* block) {
@@ -219,6 +245,39 @@ public:
         } else {
             LOG(WARNING, "Try to unmark obsolete block that is not marked: %ld\n", block_id);
         }
+    }
+    bool MarkFinishBlock(int64_t block_id) {
+        MutexLock lock(&_mu);
+        NSBlock* nsblock = NULL;
+        NSBlockMap::iterator it = _block_map.find(block_id);
+        if (it != _block_map.end()) {
+            nsblock = it->second;
+            assert(nsblock->pending_change == true);
+            nsblock->pending_change = false;
+            return true;
+        } else {
+            LOG(WARNING, "Can't find block: %ld\n", block_id);
+            return false;
+        }
+    }
+    bool GetReplicaLocation(int64_t id, std::set<int32_t>* chunkserver_id) {
+        MutexLock lock(&_mu);
+        NSBlock* nsblock = NULL;
+        NSBlockMap::iterator it = _block_map.find(id);
+        bool ret;
+        if (it != _block_map.end()) {
+            nsblock = it->second;
+            std::set<int32_t>::iterator replica_it = nsblock->replica.begin();
+            for (; replica_it != nsblock->replica.end(); ++replica_it) {
+                chunkserver_id->insert(*replica_it);
+            }
+            ret = true;
+        } else {
+            LOG(WARNING, "Can't find block: %ld\n", id);
+            ret = false;
+        }
+
+        return ret;
     }
 private:
     Mutex _mu;
@@ -284,8 +343,37 @@ void NameServerImpl::BlockReport(::google::protobuf::RpcController* controller,
                 response->add_obsolete_blocks(cur_block_id);
                 _block_manager->UnmarkObsoleteBlock(cur_block_id);
             } else {
-                _block_manager->AddBlock(cur_block_id, id, cur_block_size);
                 size += cur_block_size;
+
+                int32_t more_replica_num = 0;
+                _block_manager->AddBlock(cur_block_id, id, cur_block_size, &more_replica_num);
+                if (more_replica_num != 0) {
+                    std::vector<std::pair<int32_t, std::string> > chains;
+                    if (_chunkserver_manager->GetChunkServerChains(0, &chains)) {
+                        std::set<int32_t> cur_replica_location;
+                        _block_manager->GetReplicaLocation(cur_block_id, &cur_replica_location);
+
+                        std::vector<std::pair<int32_t, std::string> >::iterator chains_it = chains.begin();
+                        ReplicaInfo* info = NULL;
+                        int num;
+                        for (num = 0; num < more_replica_num &&
+                                chains_it != chains.end(); ++chains_it) {
+                            if (cur_replica_location.find(chains_it->first) == cur_replica_location.end()) {
+                                if (num == 0) {
+                                    info = response->add_new_replicas();
+                                    info->set_block_id(cur_block_id);
+                                }
+                                LOG(INFO, "Add new replica to chunkserver %ld\n", chains_it->first);
+                                info->add_chunkserver_address(chains_it->second);
+                                num++;
+                            }
+                        }
+                        //no suitable chunkserver
+                        if (num == 0) {
+                            _block_manager->MarkFinishBlock(cur_block_id);
+                        }
+                    }
+                }
             }
         }
         _chunkserver_manager->SetChunkServerLoad(id, size);
@@ -411,10 +499,16 @@ void NameServerImpl::AddBlock(::google::protobuf::RpcController* controller,
 }
 
 void NameServerImpl::FinishBlock(::google::protobuf::RpcController* controller,
-                         const FinishBlockRequest*,
-                         FinishBlockResponse*,
+                         const FinishBlockRequest* request,
+                         FinishBlockResponse* response,
                          ::google::protobuf::Closure* done) {
-    controller->SetFailed("Method FinishBlock() not implemented.");
+    int64_t block_id = request->block_id();
+    response->set_sequence_id(request->sequence_id());
+    if (_block_manager->MarkFinishBlock(block_id)) {
+        response->set_status(0);
+    } else {
+        response->set_status(886);
+    }
     done->Run();
 }
 

--- a/src/proto/nameserver.proto
+++ b/src/proto/nameserver.proto
@@ -122,7 +122,10 @@ message ReportBlockInfo {
     optional int64 version = 2;
     optional int64 block_size = 3;
 }
-
+message ReplicaInfo {
+    required int64 block_id = 1;
+    repeated string chunkserver_address = 2;
+}
 message BlockReportRequest {
     optional uint64 sequence_id = 1;
     optional int32 chunkserver_id = 2;
@@ -134,6 +137,7 @@ message BlockReportResponse {
     optional uint64 sequence_id = 1;
     optional int32 status = 2;
     repeated int64 obsolete_blocks = 3;
+    repeated ReplicaInfo new_replicas = 4;
 }
 
 service NameServer {


### PR DESCRIPTION
目前只支持增加副本数，减少副本数还没有做，上层接口还没有写。
大体思路是，chunkserver做blockreport时，nameserver会检查副本数，如果需要增加，则nameserver负责选出目标chunkserver ，然后回复给做blockreport的chunkserver，该chunkserver负责将自己的block复制到目标chunkserver上去，然后ACK给nameserver。
估计有一些小问题存在，所以请提出修改意见。