### PR TITLE
Fix bug

### DIFF
--- a/src/chunkserver/chunkserver_impl.h
+++ b/src/chunkserver/chunkserver_impl.h
@@ -8,6 +8,7 @@
 #define  BFS_TRUNKSERVER_IMPL_H_
 
 #include "proto/chunkserver.pb.h"
+#include "proto/nameserver.pb.h"
 #include "common/thread_pool.h"
 
 namespace bfs {
@@ -42,6 +43,7 @@ private:
                            ::google::protobuf::Closure* done,
                            ChunkServer_Stub* stub);
     void RemoveObsoleteBlocks(std::vector<int64_t> blocks);
+    void AddNewReplica(std::vector<ReplicaInfo> new_replica_info);
 private:
     BlockManager*   _block_manager;
     std::string     _data_server_addr;

--- a/src/client/bfs_client.cc
+++ b/src/client/bfs_client.cc
@@ -149,7 +149,7 @@ int BfsPut(bfs::FS* fs, int argc, char* argv[]) {
         }
         len += bytes;
     }
-    if (!file->Close()) {
+    if (!fs->CloseFile(file)) {
         fprintf(stderr, "close fail: %s\n", argv[3]);
         return 1;
     }

--- a/src/proto/nameserver.proto
+++ b/src/proto/nameserver.proto
@@ -122,7 +122,10 @@ message ReportBlockInfo {
     optional int64 version = 2;
     optional int64 block_size = 3;
 }
-
+message ReplicaInfo {
+    required int64 block_id = 1;
+    repeated string chunkserver_address = 2;
+}
 message BlockReportRequest {
     optional uint64 sequence_id = 1;
     optional int32 chunkserver_id = 2;
@@ -134,6 +137,7 @@ message BlockReportResponse {
     optional uint64 sequence_id = 1;
     optional int32 status = 2;
     repeated int64 obsolete_blocks = 3;
+    repeated ReplicaInfo new_replicas = 4;
 }
 
 service NameServer {

--- a/src/sdk/bfs.cc
+++ b/src/sdk/bfs.cc
@@ -300,7 +300,33 @@ public:
         return ret;
     }
     bool CloseFile(File* file) {
-        return file->Close();
+        int64_t block_id = -1;
+        int open_flags = -1;
+        if (BfsFileImpl* bfs_file = dynamic_cast<BfsFileImpl*>(file)) {
+            open_flags = bfs_file->_open_flags;
+            if (open_flags == O_WRONLY || open_flags == O_APPEND) {
+                block_id = bfs_file->_block_for_write->block_id();
+            }
+        } else {
+            LOG(WARNING, "Not a BfsFileImpl object?\n");
+            return false;
+        }
+        if (!file->Close()) {
+            LOG(WARNING, "Close file fail\n");
+            return false;
+        }
+        if (open_flags == O_WRONLY || open_flags == O_APPEND) {
+            FinishBlockRequest request;
+            FinishBlockResponse response;
+            request.set_sequence_id(0);
+            request.set_block_id(block_id);
+            bool ret = _rpc_client->SendRequest(_nameserver, &NameServer_Stub::FinishBlock,
+                    &request, &response, 5, 3);
+
+            return ret && response.status() == 0;
+        } else {
+            return true;
+        }
     }
     bool DeleteFile(const char* path) {
         UnlinkRequest request;


### PR DESCRIPTION
If the last packet is zero length(look at
src/sdk/bfs.cc, this may happens), then
will return before block->Write() in
WriteNextCallback, so we will never get
into FinishBlock()