### PR TITLE
include assert.h

### DIFF
--- a/tera/bfs_wrapper.cc
+++ b/tera/bfs_wrapper.cc
@@ -6,6 +6,7 @@
 
 #include "bfs_wrapper.h"
 
+#include <assert.h>
 #include <bfs.h>
 
 namespace bfs {


### PR DESCRIPTION
另外，你在编译tera目录时是不是用的百度内部的构建工具？否则默认不加-fPIC选项的话，好像是没有办法生成bfs_wrapper.so的