### PR TITLE
Update Makefile

### DIFF
--- a/tera/Makefile
+++ b/tera/Makefile
@@ -5,20 +5,21 @@ INCLUDE_PATH= -I../output/include -I../src/
 
 CXXFLAGS += $(OPT)
 
-LDFLAGS = -L../output/lib -lbfs
-TESTLDFLAGS = -rdynamic -lprotobuf -lpthread -lz -ldl
+LDFLAGS =
+TESTLDFLAGS = -rdynamic -ldl
 #-L../../../../third-64/protobuf/lib/
 
 all: bfs_wrapper.so bfs_test
 
 bfs_wrapper.so: bfs_wrapper.cc bfs_wrapper.h ../output/lib/libbfs.a
 	g++ $(CXXFLAGS) -shared -fPIC $(INCLUDE_PATH) $(LDFLAGS) -o $@ bfs_wrapper.cc ../src/common/logging.cc \
-		-Xlinker "-(" ../libbfs.a \
-		-Xlinker "-)"
-		#../../../../third-64/protobuf/lib/libprotobuf.a \
-		#../../../../public/sofa-pbrpc/output/lib/libsofa-pbrpc.a \
-		#../../../../third-64/snappy/lib/libsnappy.a \
-		#../../../../third-64/gflags/lib/libgflags.a \
+		../output/lib/libbfs.a \
+		../../../../third-64/protobuf/lib/libprotobuf.a \
+		../../../../public/sofa-pbrpc/output/lib/libsofa-pbrpc.a \
+		../../../../third-64/snappy/lib/libsnappy.a \
+		../../../../third-64/gflags/lib/libgflags.a \
+		-lpthread \
+		-lz
 	
 bfs_test: bfs_test.cc bfs_wrapper.so
 	g++ $(CXXFLAGS) -o $@ bfs_test.cc $(TESTLDFLAGS)


### PR DESCRIPTION
libpthread和libzip两个库应该在bfs_wrapper.so生成时链接，只要bfs_wrapper.so中链接过libprotobuf.a, bfs_test中便不再需要
至少在我试过的环境中这样是可行的，bfs_test也可以运行。不知道你那边怎样。