### PR TITLE
deal with chunkserver reconnect

### DIFF
--- a/src/nameserver/nameserver_impl.cc
+++ b/src/nameserver/nameserver_impl.cc
@@ -321,13 +321,24 @@ public:
     void HandleHeartBeat(const HeartBeatRequest* request, HeartBeatResponse* response) {
         MutexLock lock(&_mu);
         int32_t id = request->chunkserver_id();
-        ChunkServerInfo* info = _chunkservers[id];
-        assert(info);
-        int32_t now_time = common::timer::now_time();
-        _heartbeat_list[info->last_heartbeat()].erase(info);
-        if (_heartbeat_list[info->last_heartbeat()].empty()) {
-            _heartbeat_list.erase(info->last_heartbeat());
+        ServerMap::iterator it = _chunkservers.find(id);
+        ChunkServerInfo* info = NULL;
+        if (it != _chunkservers.end()) {
+           info = it->second;
+            assert(info);
+            _heartbeat_list[info->last_heartbeat()].erase(info);
+            if (_heartbeat_list[info->last_heartbeat()].empty()) {
+                _heartbeat_list.erase(info->last_heartbeat());
+            }
+        } else {
+            //reconnect after DeadCheck()
+            info = new ChunkServerInfo;
+            info->set_id(id);
+            info->set_address(request->data_server_addr());
+            _chunkservers[id] = info;
         }
+
+        int32_t now_time = common::timer::now_time();
         _heartbeat_list[now_time].insert(info);
         info->set_last_heartbeat(now_time);
     }

--- a/src/nameserver/nameserver_impl.cc
+++ b/src/nameserver/nameserver_impl.cc
@@ -336,6 +336,7 @@ public:
             info->set_id(id);
             info->set_address(request->data_server_addr());
             _chunkservers[id] = info;
+            ++_chunkserver_num;
         }
 
         int32_t now_time = common::timer::now_time();


### PR DESCRIPTION
处理chunkserver断网，之后网络又恢复的情况。
这种情况下，若这期间nameserver没有发生变化，则可以直接重新加入。
在chunkserver断网的这个时间区间内，有可能其某个block对应的文件已经被unlink，但是当前代码中unlink时是根据nameserver中的NSBlock信息去做MarkObsoleteBlock信息的，这样的话，当这个chunkserver重新加入时，会导致实际被删除的block得不到删除。但是不光断网有这个问题，chunkserver第一次加入或者chunkserver重启也会有这个问题。所以我感觉这种情况应由另外的逻辑处理，即在chunkserver首次或者重新加入时检查是否有obsolete block存在，这可能要求nameserver中要持久化存储一些block->file name的映射信息。

另外，好像写入速度比之前慢了一些，而且应该不是分批写入导致的，因为我测试的文件比一个buf的大小要小，我再排查一下，不知道你有没有发现这个问题。