### PR TITLE
fix wrong SetChunkServerLoad when ReportFinish

### DIFF
--- a/src/chunkserver/chunkserver_impl.cc
+++ b/src/chunkserver/chunkserver_impl.cc
@@ -563,6 +563,7 @@ void ChunkServerImpl::Routine() {
             request.set_chunkserver_id(_chunkserver_id);
             request.set_chunkserver_addr(_data_server_addr);
             request.set_namespace_version(_namespace_version);
+            request.set_is_complete(false);
 
             std::vector<BlockMeta> blocks;
             _block_manager->ListBlocks(&blocks);
@@ -607,6 +608,7 @@ bool ChunkServerImpl::ReportFinish(Block* block) {
     BlockReportRequest request;
     request.set_chunkserver_id(_chunkserver_id);
     request.set_namespace_version(_namespace_version);
+    request.set_is_complete(true);
 
     ReportBlockInfo* info = request.add_blocks();
     info->set_block_id(block->Id());

--- a/src/nameserver/nameserver_impl.cc
+++ b/src/nameserver/nameserver_impl.cc
@@ -395,7 +395,7 @@ public:
             return it->second->address();
         }
     }
-    bool SetChunkServerLoad(int32_t id, int64_t size) {
+    bool SetChunkServerLoad(int32_t id, int64_t size, bool is_complete) {
         MutexLock lock(&_mu);
         ServerMap::iterator it = _chunkservers.find(id);
         if(it == _chunkservers.end()) {
@@ -403,6 +403,10 @@ public:
             assert(0);
             return false;
         } else {
+            if (is_complete) {
+                int cur_load = it->second->data_size();
+                size += cur_load;
+            }
             it->second->set_data_size(size);
             LOG(INFO, "Get Report of ChunkServerLoad, server id: %d, load: %ld\n", id, size);
             return true;
@@ -523,7 +527,7 @@ void NameServerImpl::BlockReport(::google::protobuf::RpcController* controller,
                 }
             }
         }
-        _chunkserver_manager->SetChunkServerLoad(id, size);
+        _chunkserver_manager->SetChunkServerLoad(id, size, request->is_complete());
     }
     done->Run();
 }


### PR DESCRIPTION
当写完一个文件，ReportFinish时会做BlockReport，而当前代码中每一次BlockReport时会重置chunkserver load值。这里修正了这个错误。不过不知道当时设置is_complete这个字段有没有别的目的。

另外，在commit 3aaadd1中，将WriteNextCallback中don->Run()放到了ReportFinish之后。这样会导致写的时候延迟略有增加（因为要发送BlockReport）。如果放在前面会导致什么不一致的情况吗？