### PR TITLE
Deal with unlinked file duing chunkserver reboot

### DIFF
--- a/sandbox/deploy.sh
+++ b/sandbox/deploy.sh
@@ -1,6 +1,7 @@
 #! /bin/sh
 
 mkdir -p nameserver/bin
+mkdir -p nameserver/db
 mkdir -p chunkserver1/bin
 mkdir -p chunkserver1/data
 mkdir -p chunkserver2/bin

--- a/src/flags.cc
+++ b/src/flags.cc
@@ -7,8 +7,10 @@
 #include <gflags/gflags.h>
 
 // nameserver
-DEFINE_string(namedb_path, "./db", "Namespace database");
+DEFINE_string(namedb_path, "./db/namedb", "Namespace database");
 DEFINE_int64(namedb_cache_size, 1024L, "Namespace datebase memery cache size");
+DEFINE_string(blockdb_path, "./db/blockdb", "Block database");
+DEFINE_int64(blockdb_cache_size, 1024L, "Block datebase memery cache size");
 DEFINE_string(nameserver, "127.0.0.1", "Nameserver host");
 DEFINE_string(nameserver_port, "8828", "Nameserver port");
 DEFINE_int32(keepalive_timeout, 60, "Chunkserver keepalive timeout");

--- a/src/nameserver/nameserver_impl.cc
+++ b/src/nameserver/nameserver_impl.cc
@@ -916,6 +916,14 @@ void NameServerImpl::Unlink(::google::protobuf::RpcController* controller,
                 for (; it != chunkservers.end(); ++it) {
                     _block_manager->MarkObsoleteBlock(file_info.blocks(i), *it);
                 }
+                char idstr[64];
+                snprintf(idstr, sizeof(idstr), "%13ld", file_info.blocks(i));
+                s = _block_db->Delete(leveldb::WriteOptions(), idstr);
+                if (s.ok()) {
+                    LOG(INFO, "Remove block done: %s\n", idstr);
+                } else {
+                    LOG(WARNING, "Remove block fail: %s\n", idstr);
+                }
             }
             s = _name_db->Delete(leveldb::WriteOptions(), file_key);
             if (s.ok()) {

--- a/src/nameserver/nameserver_impl.cc
+++ b/src/nameserver/nameserver_impl.cc
@@ -25,6 +25,8 @@
 
 DECLARE_string(namedb_path);
 DECLARE_int64(namedb_cache_size);
+DECLARE_string(blockdb_path);
+DECLARE_int64(blockdb_cache_size);
 DECLARE_int32(keepalive_timeout);
 DECLARE_int32(default_replica_num);
 
@@ -434,10 +436,16 @@ NameServerImpl::NameServerImpl() {
     leveldb::Options options;
     options.create_if_missing = true;
     options.block_cache = leveldb::NewLRUCache(FLAGS_namedb_cache_size*1024L*1024L);
-    leveldb::Status s = leveldb::DB::Open(options, FLAGS_namedb_path, &_db);
+    leveldb::Status s = leveldb::DB::Open(options, FLAGS_namedb_path, &_name_db);
     if (!s.ok()) {
-        _db = NULL;
-        LOG(FATAL, "Open leveldb fail: %s\n", s.ToString().c_str());
+        _name_db = NULL;
+        LOG(FATAL, "Open _name_db fail: %s\n", s.ToString().c_str());
+    }
+    options.block_cache = leveldb::NewLRUCache(FLAGS_blockdb_cache_size * 1024L * 1024L);
+    s = leveldb::DB::Open(options, FLAGS_blockdb_path, &_block_db);
+    if (!s.ok()) {
+        _block_db = NULL;
+        LOG(FATAL, "Open _block_db fail: %s\n", s.ToString().c_str());
     }
     _namespace_version = common::timer::get_micros();
     _block_manager = new BlockManager();
@@ -549,12 +557,12 @@ void NameServerImpl::CreateFile(::google::protobuf::RpcController* controller,
     int depth = file_keys.size();
     leveldb::Status s;
     for (int i=0; i < depth-1; ++i) {
-        s = _db->Get(leveldb::ReadOptions(), file_keys[i], &info_value);
+        s = _name_db->Get(leveldb::ReadOptions(), file_keys[i], &info_value);
         if (s.IsNotFound()) {
             file_info.set_type((1<<9)|0755);
             file_info.set_ctime(time(NULL));
             file_info.SerializeToString(&info_value);
-            s = _db->Put(leveldb::WriteOptions(), file_keys[i], info_value);
+            s = _name_db->Put(leveldb::WriteOptions(), file_keys[i], info_value);
             assert (s.ok());
             LOG(INFO, "Create path recursively: %s\n",file_keys[i].c_str()+2);
         } else {
@@ -571,7 +579,7 @@ void NameServerImpl::CreateFile(::google::protobuf::RpcController* controller,
     
     const std::string& file_key = file_keys[depth-1];
     if ((flags & O_TRUNC) == 0) {
-        s = _db->Get(leveldb::ReadOptions(), file_key, &info_value);
+        s = _name_db->Get(leveldb::ReadOptions(), file_key, &info_value);
         if (s.ok()) {
             LOG(WARNING, "CreateFile %s fail: already exist!\n", file_name.c_str());
             response->set_status(1);
@@ -589,7 +597,7 @@ void NameServerImpl::CreateFile(::google::protobuf::RpcController* controller,
     file_info.set_ctime(time(NULL));
     //file_info.add_blocks();
     file_info.SerializeToString(&info_value);
-    s = _db->Put(leveldb::WriteOptions(), file_key, info_value);
+    s = _name_db->Put(leveldb::WriteOptions(), file_key, info_value);
     if (s.ok()) {
         LOG(INFO, "CreateFile %s\n", file_key.c_str());
         response->set_status(0);
@@ -615,7 +623,7 @@ void NameServerImpl::AddBlock(::google::protobuf::RpcController* controller,
     const std::string& file_key = elements[elements.size()-1];
     MutexLock lock(&_mu);
     std::string infobuf;
-    leveldb::Status s = _db->Get(leveldb::ReadOptions(), file_key, &infobuf);
+    leveldb::Status s = _name_db->Get(leveldb::ReadOptions(), file_key, &infobuf);
     if (!s.ok()) {
         LOG(WARNING, "AddBlock file not found: %s\n", path.c_str());
         response->set_status(2445);
@@ -645,7 +653,11 @@ void NameServerImpl::AddBlock(::google::protobuf::RpcController* controller,
         response->set_status(0);
         file_info.add_blocks(new_block_id);
         file_info.SerializeToString(&infobuf);
-        s = _db->Put(leveldb::WriteOptions(), file_key, infobuf);
+        s = _name_db->Put(leveldb::WriteOptions(), file_key, infobuf);
+        assert(s.ok());
+        char idstr[64];
+        snprintf(idstr, sizeof(idstr), "%13ld", new_block_id);
+        s = _block_db->Put(leveldb::WriteOptions(), idstr, path);
         assert(s.ok());
     } else {
         LOG(INFO, "AddBlock for %s failed.", path.c_str());
@@ -686,7 +698,7 @@ void NameServerImpl::GetFileLocation(::google::protobuf::RpcController* controll
     const std::string& file_key = elements[elements.size()-1];
     // Get FileInfo
     std::string infobuf;
-    leveldb::Status s = _db->Get(leveldb::ReadOptions(), file_key, &infobuf);
+    leveldb::Status s = _name_db->Get(leveldb::ReadOptions(), file_key, &infobuf);
     if (!s.ok()) {
         // No this file
         LOG(INFO, "NameServerImpl::GetFileLocation: NotFound: %s\n", request->file_name().c_str());
@@ -755,7 +767,7 @@ void NameServerImpl::ListDirectory(::google::protobuf::RpcController* controller
 
     common::timer::AutoTimer at1(100, "ListDirectory iterate", path.c_str());
     //printf("List Directory: %s, return: ", file_start_key.c_str());
-    leveldb::Iterator* it = _db->NewIterator(leveldb::ReadOptions());
+    leveldb::Iterator* it = _name_db->NewIterator(leveldb::ReadOptions());
     for (it->Seek(file_start_key); it->Valid(); it->Next()) {
         leveldb::Slice key = it->key();
         if (key.compare(file_end_key)>=0) {
@@ -792,7 +804,7 @@ void NameServerImpl::Stat(::google::protobuf::RpcController* controller,
 
     const std::string& file_key = keys[keys.size()-1];
     std::string value;
-    leveldb::Status s = _db->Get(leveldb::ReadOptions(), file_key, &value);
+    leveldb::Status s = _name_db->Get(leveldb::ReadOptions(), file_key, &value);
     if (s.ok()) {
         FileInfo* file_info = response->mutable_file_info();
         bool ret = file_info->ParseFromArray(value.data(), value.size());
@@ -837,10 +849,10 @@ void NameServerImpl::Rename(::google::protobuf::RpcController* controller,
     const std::string& old_key = oldkeys[oldkeys.size()-1];
     const std::string& new_key = newkeys[newkeys.size()-1];
     std::string value;
-    leveldb::Status s = _db->Get(leveldb::ReadOptions(), new_key, &value);
+    leveldb::Status s = _name_db->Get(leveldb::ReadOptions(), new_key, &value);
     // New file must be not found
     if (s.IsNotFound()) {
-        s = _db->Get(leveldb::ReadOptions(), old_key, &value);
+        s = _name_db->Get(leveldb::ReadOptions(), old_key, &value);
         if (s.ok()) {
             FileInfo file_info;
             bool ret = file_info.ParseFromArray(value.data(), value.size());
@@ -850,7 +862,7 @@ void NameServerImpl::Rename(::google::protobuf::RpcController* controller,
                 leveldb::WriteBatch batch;
                 batch.Put(new_key, value);
                 batch.Delete(old_key);
-                s = _db->Write(leveldb::WriteOptions(), &batch);
+                s = _name_db->Write(leveldb::WriteOptions(), &batch);
                 if (s.ok()) {
                     response->set_status(0);
                     done->Run();
@@ -890,7 +902,7 @@ void NameServerImpl::Unlink(::google::protobuf::RpcController* controller,
 
     const std::string& file_key = keys[keys.size()-1];
     std::string value;
-    leveldb::Status s = _db->Get(leveldb::ReadOptions(), file_key, &value);
+    leveldb::Status s = _name_db->Get(leveldb::ReadOptions(), file_key, &value);
     if (s.ok()) {
         FileInfo file_info;
         bool ret = file_info.ParseFromArray(value.data(), value.size());
@@ -905,7 +917,7 @@ void NameServerImpl::Unlink(::google::protobuf::RpcController* controller,
                     _block_manager->MarkObsoleteBlock(file_info.blocks(i), *it);
                 }
             }
-            s = _db->Delete(leveldb::WriteOptions(), file_key);
+            s = _name_db->Delete(leveldb::WriteOptions(), file_key);
             if (s.ok()) {
                 LOG(INFO, "Unlink done: %s\n", path.c_str());
                 ret_status = 0;
@@ -954,7 +966,7 @@ int NameServerImpl::DeleteDirectoryRecursive(std::string& path, bool recursive) 
     std::string dentry_key = keys[keys.size() - 1];
     {
         std::string value;
-        leveldb::Status s = _db->Get(leveldb::ReadOptions(), dentry_key, &value);
+        leveldb::Status s = _name_db->Get(leveldb::ReadOptions(), dentry_key, &value);
         if (!s.ok()) {
             LOG(INFO, "Delete Directory, %s is not found.", dentry_key.data() + 2);
             return 404;
@@ -980,7 +992,7 @@ int NameServerImpl::DeleteDirectoryRecursive(std::string& path, bool recursive) 
         file_end_key += '#';
     }
 
-    leveldb::Iterator* it = _db->NewIterator(leveldb::ReadOptions());
+    leveldb::Iterator* it = _name_db->NewIterator(leveldb::ReadOptions());
     it->Seek(file_start_key);
     if (it->Valid() && recursive == false) {
         LOG(WARNING, "Try to delete an unempty directory unrecursively: %s\n", dentry_key.c_str());
@@ -1013,7 +1025,7 @@ int NameServerImpl::DeleteDirectoryRecursive(std::string& path, bool recursive) 
                     _block_manager->MarkObsoleteBlock(file_info.blocks(i), *it);
                 }
             }
-            leveldb::Status s = _db->Delete(leveldb::WriteOptions(), std::string(key.data(), key.size()));
+            leveldb::Status s = _name_db->Delete(leveldb::WriteOptions(), std::string(key.data(), key.size()));
             if (s.ok()) {
                 LOG(INFO, "Unlink file done: %s\n", std::string(key.data() + 2, key.size() - 2).c_str());
             } else {
@@ -1025,7 +1037,7 @@ int NameServerImpl::DeleteDirectoryRecursive(std::string& path, bool recursive) 
     }
 
     if (ret_status == 0) {
-        leveldb::Status s = _db->Delete(leveldb::WriteOptions(), dentry_key);
+        leveldb::Status s = _name_db->Delete(leveldb::WriteOptions(), dentry_key);
         if (s.ok()) {
             LOG(INFO, "Unlink dentry done: %s\n", dentry_key.c_str() + 2);
         } else {
@@ -1056,14 +1068,14 @@ void NameServerImpl::ChangeReplicaNum(::google::protobuf::RpcController* control
 
     const std::string& file_key = keys[keys.size() - 1];
     std::string info_value;
-    leveldb::Status s = _db->Get(leveldb::ReadOptions(), file_key, &info_value);
+    leveldb::Status s = _name_db->Get(leveldb::ReadOptions(), file_key, &info_value);
     if (s.ok()) {
         FileInfo file_info;
         bool ret = file_info.ParseFromArray(info_value.data(), info_value.size());
         assert(ret);
         file_info.set_replicas(replica_num);
         file_info.SerializeToString(&info_value);
-        s = _db->Put(leveldb::WriteOptions(), file_key, info_value);
+        s = _name_db->Put(leveldb::WriteOptions(), file_key, info_value);
         assert(s.ok());
         int64_t block_id = file_info.blocks(0);
         if (_block_manager->ChangeReplicaNum(block_id, replica_num)) {

--- a/src/nameserver/nameserver_impl.h
+++ b/src/nameserver/nameserver_impl.h
@@ -85,7 +85,8 @@ private:
     /// Block map
     BlockManager* _block_manager;
     /// Namespace database
-    leveldb::DB* _db;    ///< 存储nameserver数据
+    leveldb::DB* _name_db;    ///< 存储nameserver数据
+    leveldb::DB* _block_db;
     int64_t _namespace_version;
 };
 


### PR DESCRIPTION
处理在某个replica所在的chunkserver重启过程中， 文件被删除的情况。
在nameserver中，额外使用了一个leveldb，记录block->filename的映射。当chunkserver重启，第一次做blockreport时，会检查这个leveldb，如果发现找不到对应block，说明其所对应的文件已经被删除，则在blockreport的response中回复删除这个block。对于DeadCheck中，发现某个chunkserver挂掉后，若这个chunkserver上的某个block被标记为obsolete，那么将这个标记信息删除，真正的删除动作会在chunkserver重启后完成。
这个方法也可以处理chunkserver断网，被DeadCheck，然后又恢复的情况。因为DeadCheck之后，会将_chunkserver_block_map中该chunkserver的信息删除，这样，CheckNewChunkserver会返回true，从而转到跟chunkserver重启时相同的逻辑。