### PR TITLE
Rebuild _block_map && deal with missed unlink operation

### DIFF
--- a/src/nameserver/nameserver_impl.cc
+++ b/src/nameserver/nameserver_impl.cc
@@ -1147,11 +1147,9 @@ void NameServerImpl::ChangeReplicaNum(::google::protobuf::RpcController* control
 void NameServerImpl::RebuildBlockMap() {
     MutexLock lock(&_mu);
     leveldb::Iterator* it = _db->NewIterator(leveldb::ReadOptions());
-    std::string info_value;
     for (it->SeekToFirst(); it->Valid(); it->Next()) {
-        info_value = it->value().ToString();
         FileInfo file_info;
-        bool ret = file_info.ParseFromString(info_value);
+        bool ret = file_info.ParseFromArray(it->value().data(), it->value().size());
         assert(ret);
         if ((file_info.type() & (1 << 9)) == 0) {
             //a file

--- a/src/nameserver/nameserver_impl.cc
+++ b/src/nameserver/nameserver_impl.cc
@@ -557,7 +557,6 @@ void NameServerImpl::BlockReport(::google::protobuf::RpcController* controller,
             }
 
             size += cur_block_size;
-            _block_manager->UpdateBlockInfo(cur_block_id, id, cur_block_size, &more_replica_num);
             _chunkserver_manager->AddBlock(id, cur_block_id);
             if (more_replica_num != 0) {
                 std::vector<std::pair<int32_t, std::string> > chains;

--- a/src/nameserver/nameserver_impl.cc
+++ b/src/nameserver/nameserver_impl.cc
@@ -83,7 +83,8 @@ public:
         int32_t expect_replica_num;
         bool pending_change;
         NSBlock(int64_t block_id)
-         : id(block_id), version(0), expect_replica_num(FLAGS_default_replica_num),
+         : id(block_id), version(0), block_size(0),
+           expect_replica_num(FLAGS_default_replica_num),
            pending_change(true) {
         }
     };

--- a/src/nameserver/nameserver_impl.h
+++ b/src/nameserver/nameserver_impl.h
@@ -74,6 +74,7 @@ public:
                        ::google::protobuf::Closure* done);
 private:
     int DeleteDirectoryRecursive(std::string& path, bool recursive);
+    void RebuildBlockMap();
 
 private:
     /// Global thread pool


### PR DESCRIPTION
基本上是按那个思路实现的。RebuildBlockMap还有待加强，如replica num信息没有rebuild出来。
我测了几个用例没什么问题，明天再仔细测一下。DeadCheck和Unlink发生先后顺序不同可能会导致一些边界情况。