### PR TITLE
Fix FSImpl::CloseFile

### DIFF
--- a/src/sdk/bfs.cc
+++ b/src/sdk/bfs.cc
@@ -308,11 +308,14 @@ public:
     bool CloseFile(File* file) {
         int64_t block_id = -1;
         int open_flags = -1;
+        bool empty_file = false;
         BfsFileImpl* bfs_file = dynamic_cast<BfsFileImpl*>(file);
         if (bfs_file) {
             open_flags = bfs_file->_open_flags;
-            if (bfs_file->_block_for_write &&
-                ((open_flags & O_WRONLY) || open_flags == O_APPEND)) {
+            if (!bfs_file->_block_for_write) {
+                empty_file = true;
+            }
+            if (!empty_file && ((open_flags & O_WRONLY) || open_flags == O_APPEND)) {
                 block_id = bfs_file->_block_for_write->block_id();
             }
         } else {
@@ -323,8 +326,7 @@ public:
             LOG(WARNING, "Close file fail\n");
             return false;
         }
-        if (bfs_file->_block_for_write &&
-            ((open_flags & O_WRONLY) || open_flags == O_APPEND)) {
+        if (!empty_file && ((open_flags & O_WRONLY) || open_flags == O_APPEND)) {
             FinishBlockRequest request;
             FinishBlockResponse response;
             request.set_sequence_id(0);


### PR DESCRIPTION
commit 50422079中fix了写空文件的问题。但是，对于非空文件，经过BfsFileImpl::Close之后，_block_for_write也会变为NULL，会导致FSImple::CloseFile中不再给nameserver发送FinishBlock的消息。这将导致nameserver中NSBlock的状态一直为pending_change。