### PR TITLE
Rebuild replica num info when nameserver start

### DIFF
--- a/src/nameserver/nameserver_impl.cc
+++ b/src/nameserver/nameserver_impl.cc
@@ -236,15 +236,13 @@ public:
     bool ChangeReplicaNum(int64_t block_id, int32_t replica_num) {
         MutexLock lock(&_mu);
         NSBlockMap::iterator it = _block_map.find(block_id);
-        bool ret = false;
         if (it == _block_map.end()) {
-            //maybe not report yet
+            assert(0);
         } else {
             NSBlock* nsblock = it->second;
             nsblock->expect_replica_num = replica_num;
-            ret = true;
+            return true;
         }
-        return ret;
     }
     void InitBlockInfo(int64_t block_id) {
         MutexLock lock(&_mu);
@@ -1159,6 +1157,8 @@ void NameServerImpl::RebuildBlockMap() {
             for (int i = 0; i < file_info.blocks_size(); i++) {
                 int64_t block_id = file_info.blocks(i);
                 _block_manager->InitBlockInfo(block_id);
+                _block_manager->ChangeReplicaNum(block_id, file_info.replicas());
+                _block_manager->MarkFinishBlock(block_id);
             }
         }
     }

--- a/src/nameserver/nameserver_impl.cc
+++ b/src/nameserver/nameserver_impl.cc
@@ -179,7 +179,7 @@ public:
             LOG(WARNING, "Block %ld is not marked obsolete\n", block_id);
         }
     }
-    bool MarkFinishBlock(int64_t block_id) {
+    bool MarkBlockStable(int64_t block_id) {
         MutexLock lock(&_mu);
         NSBlock* nsblock = NULL;
         NSBlockMap::iterator it = _block_map.find(block_id);
@@ -565,7 +565,7 @@ void NameServerImpl::BlockReport(::google::protobuf::RpcController* controller,
             size += cur_block_size;
             _chunkserver_manager->AddBlock(id, cur_block_id);
             if (more_replica_num != 0 && new_chunkserver) {
-                _block_manager->MarkFinishBlock(cur_block_id);
+                _block_manager->MarkBlockStable(cur_block_id);
             } else if (more_replica_num != 0 && !new_chunkserver) {
                 std::vector<std::pair<int32_t, std::string> > chains;
                 ///TODO: Not get all chunkservers, but get more.
@@ -590,7 +590,7 @@ void NameServerImpl::BlockReport(::google::protobuf::RpcController* controller,
                     }
                     //no suitable chunkserver
                     if (num == 0) {
-                        _block_manager->MarkFinishBlock(cur_block_id);
+                        _block_manager->MarkBlockStable(cur_block_id);
                     }
                 }
             }
@@ -732,7 +732,7 @@ void NameServerImpl::FinishBlock(::google::protobuf::RpcController* controller,
                          ::google::protobuf::Closure* done) {
     int64_t block_id = request->block_id();
     response->set_sequence_id(request->sequence_id());
-    if (_block_manager->MarkFinishBlock(block_id)) {
+    if (_block_manager->MarkBlockStable(block_id)) {
         response->set_status(0);
     } else {
         response->set_status(886);
@@ -1165,7 +1165,7 @@ void NameServerImpl::RebuildBlockMap() {
                 int64_t block_id = file_info.blocks(i);
                 _block_manager->InitBlockInfo(block_id);
                 _block_manager->ChangeReplicaNum(block_id, file_info.replicas());
-                _block_manager->MarkFinishBlock(block_id);
+                _block_manager->MarkBlockStable(block_id);
             }
         }
     }

--- a/src/nameserver/nameserver_impl.cc
+++ b/src/nameserver/nameserver_impl.cc
@@ -653,6 +653,7 @@ void NameServerImpl::CreateFile(::google::protobuf::RpcController* controller,
     }
     file_info.set_id(0);
     file_info.set_ctime(time(NULL));
+    file_info.set_replicas(FLAGS_default_replica_num);
     //file_info.add_blocks();
     file_info.SerializeToString(&info_value);
     s = _db->Put(leveldb::WriteOptions(), file_key, info_value);
@@ -693,7 +694,7 @@ void NameServerImpl::AddBlock(::google::protobuf::RpcController* controller,
         assert(0);
     }
     /// replica num
-    int replica_num = FLAGS_default_replica_num;
+    int replica_num = file_info.replicas();
     /// check lease for write
     std::vector<std::pair<int32_t, std::string> > chains;
     if (_chunkserver_manager->GetChunkServerChains(replica_num, &chains)) {


### PR DESCRIPTION
在nameserver启动时重建replica num信息。

但是有一个问题，文件被写完后，会向nameserver发送finish block消息，nameserver会将这个block的pending_change改为false。nameserver重启后，这个状态丢失。究竟应当将其初始化为true还是false?

如果置为true的话，更改为false的时机不好选择，如果某些chunkserver挂掉，则这个block不会被复制。如果置为false的话，那么由于chunkserver连接到nameserver的顺序不同，有可能造成大量的block产生不必要的复制。

这里用的方法是，将其置为false。在nameserver处理block report时，若发现某个chunkserver是第一次做block report，则对其不考虑block的复制。这样，相当于在nameserver重启后，留一个缓冲时间，让充分数目的chunkserver进行连接。