### PR TITLE
Update tera/Makefile

### DIFF
--- a/tera/Makefile
+++ b/tera/Makefile
@@ -5,18 +5,18 @@ INCLUDE_PATH= -I../output/include -I../src/
 
 CXXFLAGS += $(OPT)
 
-LDFLAGS = -L../output/lib -lbfs
 TESTLDFLAGS = -rdynamic -lprotobuf -lpthread -lz -ldl -L../../../../third-64/protobuf/lib/
 
 all: bfs_wrapper.so bfs_test
 
 bfs_wrapper.so: bfs_wrapper.cc bfs_wrapper.h ../output/lib/libbfs.a
-	g++ $(CXXFLAGS) -shared -fPIC $(INCLUDE_PATH) $(LDFLAGS) -o $@ bfs_wrapper.cc ../src/common/logging.cc \
+	g++ $(CXXFLAGS) -shared -fPIC $(INCLUDE_PATH) -o $@ bfs_wrapper.cc ../src/common/logging.cc \
 		-Xlinker "-(" ../libbfs.a \
 		../../tera/thirdparty/lib/libprotobuf.a \
 		../../tera/thirdparty/lib/libsofa-pbrpc.a \
 		../../tera/thirdparty/lib/libsnappy.a \
 		../../tera/thirdparty/lib/libgflags.a \
+		-lpthread \
 		-Xlinker "-)"
 
 	


### PR DESCRIPTION
pthread这个库有点奇怪：
libpthread.so文件是一个“伪so”，打开这个文件便可以发现，并不是一个真正的so文件，而是重定向到了另外两个文件，其中是一个so文件，另一个是.a文件。
对于so文件，在链接时，会将so中的所有符号输出到输出文件中，而对于.a文件，只是查找当前未定义符号，如果发现在.a文件中存在，则将这个符号的相关信息输出。
这就造成了一个问题，如果libpthread是个.so文件，那么-lpthread选项放到前面后面都可以，因为so会将所有符号输出。但如果libpthread是个.a文件，那么只能将-lpthread放到后面，因为最开始并没有未定义符号，-lpthread便失去了应有的作用。

但现在是两个文件，一个.so，一个.a，于是放在后面比较保险。否则虽然可以编译通过，但是运行时会提示诸如undefined symbol: pthread_create之类的错误。我在Ubuntu14.04和CentOS下尝试发现都是这样，不知道你那边用的是什么发行版，可能在那个发行版中，libpthread.so就是一个真正的.so。
