### PR TITLE
Report all blocks accross several block reports

### DIFF
--- a/src/chunkserver/chunkserver_impl.cc
+++ b/src/chunkserver/chunkserver_impl.cc
@@ -581,9 +581,10 @@ void ChunkServerImpl::Routine() {
                 std::vector<BlockMeta>(blocks).swap(blocks);
             }
             size_t blocks_num = blocks.size();
+            size_t last_block = ticks ?
+                next_report_offset + FLAGS_blockreport_size : blocks_num;
             size_t i = next_report_offset;
-            for (; i < next_report_offset + FLAGS_blockreport_size
-                    && i < blocks_num; i++) {
+            for (; i < last_block && i < blocks_num; i++) {
                 ReportBlockInfo* info = request.add_blocks();
                 info->set_block_id(blocks[i].block_id);
                 info->set_block_size(blocks[i].block_size);

--- a/src/chunkserver/chunkserver_impl.cc
+++ b/src/chunkserver/chunkserver_impl.cc
@@ -637,7 +637,7 @@ bool ChunkServerImpl::ReportFinish(Block* block) {
     request.set_chunkserver_id(_chunkserver_id);
     request.set_chunkserver_addr(_data_server_addr);
     request.set_namespace_version(_namespace_version);
-    request.set_is_complete(true);
+    request.set_is_complete(false);
 
     ReportBlockInfo* info = request.add_blocks();
     info->set_block_id(block->Id());

--- a/src/chunkserver/chunkserver_impl.cc
+++ b/src/chunkserver/chunkserver_impl.cc
@@ -33,6 +33,7 @@ DECLARE_string(nameserver_port);
 DECLARE_string(chunkserver_port);
 DECLARE_int32(heartbeat_interval);
 DECLARE_int32(blockreport_interval);
+DECLARE_int32(blockreport_size);
 DECLARE_int32(write_buf_size);
 DECLARE_int32(chunkserver_thread_num);
 
@@ -546,6 +547,8 @@ void* ChunkServerImpl::RoutineWrapper(void* arg) {
 void ChunkServerImpl::Routine() {
     static int64_t ticks = 0;
     int64_t next_report = -1;
+    size_t next_report_offset = 0;
+    std::vector<BlockMeta> blocks;
     while (!_quit) {
         // heartbeat
         if (ticks % FLAGS_heartbeat_interval == 0) {
@@ -571,15 +574,27 @@ void ChunkServerImpl::Routine() {
             request.set_chunkserver_id(_chunkserver_id);
             request.set_chunkserver_addr(_data_server_addr);
             request.set_namespace_version(_namespace_version);
-            request.set_is_complete(false);
 
-            std::vector<BlockMeta> blocks;
-            _block_manager->ListBlocks(&blocks);
-            for (size_t i = 0; i < blocks.size(); i++) {
+            if (next_report_offset == 0) {
+                blocks.clear();
+                _block_manager->ListBlocks(&blocks);
+                std::vector<BlockMeta>(blocks).swap(blocks);
+            }
+            size_t blocks_num = blocks.size();
+            size_t i = next_report_offset;
+            for (; i < next_report_offset + FLAGS_blockreport_size
+                    && i < blocks_num; i++) {
                 ReportBlockInfo* info = request.add_blocks();
                 info->set_block_id(blocks[i].block_id);
                 info->set_block_size(blocks[i].block_size);
                 info->set_version(0);
+            }
+            next_report_offset = i;
+            if (next_report_offset >= blocks_num) {
+                next_report_offset = 0;
+                request.set_is_complete(true);
+            } else {
+                request.set_is_complete(false);
             }
             BlockReportResponse response;
             if (!_rpc_client->SendRequest(_nameserver, &NameServer_Stub::BlockReport,

--- a/src/flags.cc
+++ b/src/flags.cc
@@ -20,6 +20,7 @@ DEFINE_string(block_store_path, "./data", "Data path");
 DEFINE_string(chunkserver_port, "8825", "Chunkserver port");
 DEFINE_int32(heartbeat_interval, 5, "Heartbeat interval");
 DEFINE_int32(blockreport_interval, 60, "blockreport_interval");
+DEFINE_int32(blockreport_size, 100, "blockreport_size");
 DEFINE_int32(chunkserver_log_level, 4, "Nameserver log level");
 DEFINE_string(chunkserver_warninglog, "./wflog", "Warning log file");
 DEFINE_int32(write_buf_size, 1024*1024, "Block write buffer size, bytes");

--- a/src/nameserver/nameserver_impl.cc
+++ b/src/nameserver/nameserver_impl.cc
@@ -487,11 +487,14 @@ public:
             assert(0);
             return false;
         } else {
-            if (is_complete) {
-                int cur_load = it->second->data_size();
-                size += cur_load;
+            int64_t cur_report_size = it->second->current_report_size();
+            cur_report_size += size;
+            if (!is_complete) {
+                it->second->set_current_report_size(cur_report_size);
+            } else {
+                it->second->set_data_size(cur_report_size);
+                it->second->set_current_report_size(0);
             }
-            it->second->set_data_size(size);
             LOG(INFO, "Get Report of ChunkServerLoad, server id: %d, load: %ld\n", id, size);
             return true;
         }

--- a/src/proto/file.proto
+++ b/src/proto/file.proto
@@ -17,6 +17,7 @@ message ChunkServerInfo {
     optional string address = 2;
     optional int32 last_heartbeat = 3;
     optional int64 data_size = 4;
-    optional int64 disk_size = 5;
+    optional int64 current_report_size = 5;
+    optional int64 disk_size = 6;
 }
 


### PR DESCRIPTION
有两种选择：
1.固定一轮完整的汇报过程中，block report的次数。这样，随着block数目的增加，每次report的大小增加，若block数目较多时，则一次block report的数据量将变大。
2.固定一轮完整的汇报过程中，每次block report中block的数目。但是，承随着block数目的增加，每轮所需block report数目也增加，拉长了一轮完整汇报所需的时间。

这个实现采用的是第二种方法。
根据上层系统的需要，每个chunkserver上大约会有多少block？
不管采用哪种实现，都将导致chunkserver的负载在一轮完整汇报结束前不能得到及时更新。可以让chunkserver自己来汇报负载，然后nameserver根据情况做适当修正来解决这个问题，不过当前还没有实现。