### PR TITLE
Close file descriptor when it's not being used

### DIFF
--- a/src/chunkserver/chunkserver_impl.cc
+++ b/src/chunkserver/chunkserver_impl.cc
@@ -436,6 +436,7 @@ public:
             Block* block = new Block(meta, _store_path, _thread_pool);
             block->AddRef();
             _block_map[block_id] = block;
+            block->MarkFinish();
             _block_num ++;
         }
         delete it;

--- a/src/chunkserver/chunkserver_impl.cc
+++ b/src/chunkserver/chunkserver_impl.cc
@@ -26,6 +26,7 @@
 #include "common/timer.h"
 #include "common/sliding_window.h"
 #include "common/logging.h"
+#include "common/lru.h"
 
 DECLARE_string(block_store_path);
 DECLARE_string(nameserver);
@@ -168,6 +169,10 @@ public:
         _finished = true;
         return true;
     }
+    bool IsFinish() {
+        MutexLock lock(&_mu, "Block::IsFinish", 1000);
+        return _finished;
+    }
     /// Read operation.
     int32_t Read(char* buf, int32_t len, int64_t offset) {
         MutexLock lock(&_mu, "Block::Read", 1000);
@@ -252,25 +257,33 @@ public:
     }
     /// Flush block to disk.
     void Close() {
-        LOG(INFO, "Block %ld Flush to %s", _meta.block_id, _disk_file.c_str());
-        MutexLock lock(&_mu, "Block::Close", 1000);
-        if (_bufdatalen) {
-            _block_buf_list.push_back(std::make_pair(_blockbuf, _bufdatalen));
-            this->AddRef();
-            _thread_pool->AddTask(boost::bind(&Block::DiskWrite, this));
+        if (_finished) {
+            if (_file_desc >= 0) {
+                int ret = close(_file_desc);
+                assert(ret == 0);
+                _file_desc = -1;
+            }
+        } else {
+            LOG(INFO, "Block %ld Flush to %s", _meta.block_id, _disk_file.c_str());
+            MutexLock lock(&_mu, "Block::Close", 1000);
+            if (_bufdatalen) {
+                _block_buf_list.push_back(std::make_pair(_blockbuf, _bufdatalen));
+                this->AddRef();
+                _thread_pool->AddTask(boost::bind(&Block::DiskWrite, this));
+                _blockbuf = NULL;
+                _bufdatalen = 0;
+            }
+            /*
+            ///TODO: Error handling
+            int ret = close(_file_desc);
+            assert(ret == 0);
+            _file_desc = -1;
+            delete _blockbuf;
             _blockbuf = NULL;
-            _bufdatalen = 0;
+            g_block_buffers.Dec();
+            LOG(INFO, "Block %ld %s closed", _meta.block_id, _disk_file.c_str());
+            */
         }
-        /*
-        ///TODO: Error handling
-        int ret = close(_file_desc);
-        assert(ret == 0);
-        _file_desc = -1;
-        delete _blockbuf;
-        _blockbuf = NULL;
-        g_block_buffers.Dec();
-        LOG(INFO, "Block %ld %s closed", _meta.block_id, _disk_file.c_str());
-        */
     }
     void AddRef() {
         common::atomic_inc(&_refs);
@@ -378,11 +391,13 @@ class BlockManager {
 public:
     BlockManager(ThreadPool* thread_pool, std::string store_path)
         :_thread_pool(thread_pool), _store_path(store_path),
-         _metadb(NULL), _block_num(0) {
+        _block_cache(NULL), _metadb(NULL), _block_num(0) {
         ///TODO: Multi disk support
         if (_store_path.empty() || _store_path[_store_path.size() - 1] != '/') {
             _store_path += "/";
         }
+        _block_cache = new common::LRU<int64_t, Block*>(100, RemoveBlockCacheCallback);
+        assert(_block_cache);
     }
     ~BlockManager() {
         for (BlockMap::iterator it = _block_map.begin();
@@ -390,6 +405,8 @@ public:
             it->second->DecRef();
         }
         _block_map.clear();
+        delete _block_cache;
+        _block_cache = NULL;
         delete _metadb;
         _metadb = NULL;
     }
@@ -448,27 +465,40 @@ public:
     Block* FindBlock(int64_t block_id, bool create_if_missing, int64_t* sync_time = NULL) {
         bool new_create = false;
         Block* block = NULL;
+        Block** cached_block = NULL;
         {
             MutexLock lock(&_mu, "BlockManger::Find", 1000);
             g_find_ops.Inc();
-            BlockMap::iterator it = _block_map.find(block_id);
-            if (it != _block_map.end()) {
-                block = it->second;
-            } else if (create_if_missing) {
-                ///TODO: LRU block map
-                BlockMeta meta;
-                meta.block_id = block_id;
-                block = new Block(meta, _store_path, _thread_pool);
-                new_create = true;
-                // for block_map
-                block->AddRef();
-                _block_map[block_id] = block;
+            cached_block = _block_cache->Find(block_id);
+            if (cached_block) {
+                block = *cached_block;
             } else {
-                // not found
+                BlockMap::iterator it = _block_map.find(block_id);
+                if (it != _block_map.end()) {
+                    block = it->second;
+                } else if (create_if_missing) {
+                    ///TODO: LRU block map
+                    BlockMeta meta;
+                    meta.block_id = block_id;
+                    block = new Block(meta, _store_path, _thread_pool);
+                    new_create = true;
+                    // for block_map
+                    block->AddRef();
+                    _block_map[block_id] = block;
+                } else {
+                    // not found
+                }
+
+                if (block) {
+                    _block_cache->Insert(block_id, block);
+                    // for _block_cache
+                    block->AddRef();
+                }
             }
         }
         // Write meta & sync
         if (new_create && !SyncBlockMeta(block->GetMeta(), sync_time)) {
+            _block_cache->Remove(block_id);
             delete block;
             block = NULL;
         }
@@ -498,12 +528,11 @@ public:
         return true;
     }
     bool CloseBlock(Block* block) {
+        // Disk flush & sync
+        block->Close();
         if (!block->MarkFinish()) {
             return false;
         }
-        // Disk flush & sync
-        block->Close();
-        
         // Update meta
         BlockMeta meta = block->GetMeta();
         return SyncBlockMeta(meta, NULL);
@@ -517,6 +546,7 @@ public:
                 LOG(WARNING, "Try to remove block that does not exist: %ld\n", block_id);
                 return false;
             }
+            _block_cache->Remove(block_id);
             block = it->second;
         }
 
@@ -551,10 +581,18 @@ public:
         }
     }
 private:
+    static void RemoveBlockCacheCallback(int64_t &block_id, Block* &block) {
+        if (block->IsFinish()) {
+            block->Close();
+        }
+        block->DecRef();
+    }
+private:
     ThreadPool* _thread_pool;
     std::string _store_path;
     typedef std::map<int64_t, Block*> BlockMap;
     BlockMap  _block_map;
+    common::LRU<int64_t, Block*>* _block_cache;
     leveldb::DB* _metadb;
     int64_t _block_num;
     Mutex   _mu;

--- a/src/common/lru.h
+++ b/src/common/lru.h
@@ -1,0 +1,89 @@
+#ifndef COMMON_LRU_H_
+#define COMMON_LRU_H_
+
+#include <list>
+#include <boost/function.hpp>
+#include <boost/unordered_map.hpp>
+
+#include "mutex.h"
+
+namespace common {
+
+template<typename T1, typename T2>
+class LRU {
+public:
+    typedef boost::function<void (T1&, T2&)> LRUCallback;
+    typedef std::list<std::pair<T1, T2> > List;
+    typedef typename List::iterator List_Iter;
+    typedef boost::unordered_map<T1, List_Iter> Map;
+    typedef typename Map::iterator Map_Iter;
+    LRU(int32_t capacity, LRUCallback callback) :
+        capacity_(capacity), size_(0), callback_(callback) {
+    }
+    ~LRU() {
+        for (List_Iter list_it = list_.begin();
+                list_it != list_.end(); ++list_it) {
+            callback_(list_it->first, list_it->second);
+        }
+    }
+    T2* Find(const T1& key) {
+        MutexLock lock(&mu_);
+        Map_Iter map_it = index_map_.find(key);
+        if (map_it == index_map_.end()) {
+            return NULL;
+        } else {
+            List_Iter list_it = map_it->second;
+            list_.splice(list_.begin(), list_, list_it);
+            return &(list_.begin()->second);
+        }
+    }
+    void Remove(const T1& key) {
+        MutexLock lock(&mu_);
+        Map_Iter map_it = index_map_.find(key);
+        if (map_it != index_map_.end()) {
+            List_Iter list_it = map_it->second;
+            callback_(list_it->first, list_it->second);
+            list_.erase(list_it);
+            index_map_.erase(map_it);
+            size_--;
+        }
+    }
+    void Insert(const T1& key, const T2& value) {
+        MutexLock lock(&mu_);
+        Map_Iter map_it = index_map_.find(key);
+        if (map_it != index_map_.end()) {
+            // already exist
+            List_Iter list_it = map_it->second;
+            list_.splice(list_.begin(), list_, list_it);
+            list_.begin()->second = value;
+        } else {
+            if (size_ == capacity_) {
+                List_Iter list_it = list_.end();
+                list_it--;
+                callback_(list_it->first, list_it->second);
+                list_.splice(list_.begin(), list_, list_it);
+                index_map_.erase(list_it->first);
+                list_it->first = key;
+                list_it->second = value;
+                index_map_[key] = list_it;
+            } else {
+                list_.push_front(std::make_pair(key, value));
+                index_map_[key] = list_.begin();
+                size_++;
+            }
+        }
+    }
+    int32_t Size() const {
+        MutexLock lock(&mu_);
+        return size_;
+    }
+private:
+    int32_t capacity_;
+    int32_t size_;
+    List list_;
+    Map index_map_;
+    LRUCallback callback_;
+    Mutex mu_;
+};
+}
+#endif


### PR DESCRIPTION
我的想法是，先实现一个LRU，然后将Block的指针放到这个lru中，当指针被从lru中移除时，如果block对应的文件处于打开状态，则在回调函数中将其关闭。
这样也会加快读取的速度，对于经常读取的block，不用再去较大的map中查找了。
当前只完成了LRU的实现。