### PR TITLE
fix Pread & small_test.sh

### DIFF
--- a/sandbox/small_test.sh
+++ b/sandbox/small_test.sh
@@ -20,6 +20,8 @@ sleep 3
 
 ./bfs_client get /bin/bfs_client ./binary
 
+diff ./bfs_client ./binary > /dev/null
+
 rm -rf ./binary
 
 ./bfs_client ls /
@@ -42,6 +44,8 @@ touch empty_file1
 ./bfs_client put ./empty_file1 /ef
 
 ./bfs_client get /ef ./empty_file2
+
+diff ./empty_file1 ./empty_file2 > /dev/null
 
 rm -rf empty_file*
 

--- a/src/sdk/bfs.cc
+++ b/src/sdk/bfs.cc
@@ -433,9 +433,10 @@ BfsFileImpl::~BfsFileImpl () {
 }
 
 int32_t BfsFileImpl::Pread(char* buf, int32_t read_len, int64_t offset, bool reada) {
-    if (reada) {
+    {
         MutexLock lock(&_mu, "Pread read buffer", 1000);
-        if (_reada_base <= offset && _reada_base + _reada_buf_len >= offset + read_len) {
+        if (_reada_buffer && _reada_base <= offset &&
+                _reada_base + _reada_buf_len >= offset + read_len) {
             memcpy(buf, _reada_buffer + (offset - _reada_base), read_len);
             //LOG(INFO, "Read %s %ld from cache %ld", _name.c_str(), offset, read_len);
             return read_len;


### PR DESCRIPTION
从上下文来判断， reada的语义应该是　要不要在当前读操作中进行预读，而不是　当前读操作要不要使用预读的内容。
如果将reada设为false，是不是意味着这可能是一个随机读，那么这时候是不是不更新_reada_buffer更好一些？好像leveldb中顺序读和随机读有不同的接口？　