### PR TITLE
Fix block version bug

### DIFF
--- a/src/nameserver/nameserver_impl.cc
+++ b/src/nameserver/nameserver_impl.cc
@@ -269,8 +269,11 @@ public:
             return false;
         } else {
             nsblock = it->second;
-            if (nsblock->version >= 0 && block_version == 0) {
-                LOG(INFO, "block #%ld on slow chunkserver: %d, drop it", id, server_id);
+            if (nsblock->version >= 0 && block_version >= 0 &&
+                    nsblock->version != block_version) {
+                LOG(INFO, "block #%ld on slow chunkserver: %d,"
+                        " NSB version: %ld, cs version: %ld, drop it",
+                        id, server_id, nsblock->version, block_version);
                 return false;
             }
             if (nsblock->block_size !=  block_size && block_size) {

--- a/src/proto/chunkserver.proto
+++ b/src/proto/chunkserver.proto
@@ -28,12 +28,14 @@ message ReadBlockRequest {
     optional int64 block_id = 2;
     optional int64 offset = 3;
     optional int32 read_len = 4;
+    optional bool require_block_version = 5 [default = false];
 }
 message ReadBlockResponse {
     optional int64 sequence_id = 1;
     optional int32 status = 2;
     optional bytes databuf = 3;
     repeated int64 timestamp = 9;
+    optional int32 block_version = 4;
 }
 
 message GetBlockInfoRequest {


### PR DESCRIPTION
* 对于写完的文件，block version有可能等于0(block version初始值为-1)，由于nameserver上的block version是sdk在得知写成功后，才更新的，而sdk在得知写成功时，chunkserver已经完成所有写入，并更新了block version，所以后续进行block version的校验是安全的。
* 之前对于pull过来的block，没有设置block version。现改为在pull过程结束时，设置block version。
