### PR TITLE
Skip unfinished block in UpdateBlockInfo & fix block version

### DIFF
--- a/src/chunkserver/chunkserver_impl.cc
+++ b/src/chunkserver/chunkserver_impl.cc
@@ -241,7 +241,7 @@ bool ChunkServerImpl::ReportFinish(Block* block) {
     ReportBlockInfo* info = request.add_blocks();
     info->set_block_id(block->Id());
     info->set_block_size(block->Size());
-    info->set_version(0);
+    info->set_version(block->GetVersion());
     BlockReportResponse response;
     if (!rpc_client_->SendRequest(nameserver_, &NameServer_Stub::BlockReport,
             &request, &response, 20, 3)) {

--- a/src/nameserver/block_mapping.cc
+++ b/src/nameserver/block_mapping.cc
@@ -151,31 +151,31 @@ bool BlockMapping::UpdateBlockInfo(int64_t id, int32_t server_id, int64_t block_
         }
     }
 
-   std::pair<std::set<int32_t>::iterator, bool> ret = nsblock->replica.insert(server_id);
-   //skip unfinished blocks
-   if (block_version >= 0) {
-       int32_t cur_replica_num = nsblock->replica.size();
-       int32_t expect_replica_num = nsblock->expect_replica_num;
-       if (cur_replica_num != expect_replica_num) {
-           if (!nsblock->pending_change) {
-               nsblock->pending_change = true;
-               if (cur_replica_num > expect_replica_num) {
-                   LOG(INFO, "too much replica cur=%d expect=%d server=%d",
-                           server_id, cur_replica_num, expect_replica_num);
-                   nsblock->replica.erase(ret.first);
-                   return false;
-               } else {
-                   // add new replica
-                   if (more_replica_num) {
-                       *more_replica_num = expect_replica_num - cur_replica_num;
-                       LOG(INFO, "Need to add %d new replica for #%ld cur=%d expect=%d",
-                               *more_replica_num, id, cur_replica_num, expect_replica_num);
-                   }
-               }
-           }
-       }
-   }
-   return true;
+    std::pair<std::set<int32_t>::iterator, bool> ret = nsblock->replica.insert(server_id);
+    //skip unfinished blocks
+    if (block_version >= 0) {
+        int32_t cur_replica_num = nsblock->replica.size();
+        int32_t expect_replica_num = nsblock->expect_replica_num;
+        if (cur_replica_num != expect_replica_num) {
+            if (!nsblock->pending_change) {
+                nsblock->pending_change = true;
+                if (cur_replica_num > expect_replica_num) {
+                    LOG(INFO, "too much replica cur=%d expect=%d server=%d",
+                            server_id, cur_replica_num, expect_replica_num);
+                    nsblock->replica.erase(ret.first);
+                    return false;
+                } else {
+                    // add new replica
+                    if (more_replica_num) {
+                        *more_replica_num = expect_replica_num - cur_replica_num;
+                        LOG(INFO, "Need to add %d new replica for #%ld cur=%d expect=%d",
+                                *more_replica_num, id, cur_replica_num, expect_replica_num);
+                    }
+                }
+            }
+        }
+    }
+    return true;
 }
 
 void BlockMapping::RemoveBlocksForFile(const FileInfo& file_info) {


### PR DESCRIPTION
cs在向ns ReportFinish时也会携带block version，虽然现在还没有用到这个version，不过之前的是错的。
另外，在UpdateBlockInfo中，跳过对还没有finish的block的副本数的检查